### PR TITLE
Print to stderr instead of stdout

### DIFF
--- a/core/dxf_parseable.go
+++ b/core/dxf_parseable.go
@@ -1,6 +1,8 @@
 package core
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // TypeParser parses a specific DataType, returning an error or nil if the parsing was successful.
 type TypeParser interface {
@@ -148,7 +150,7 @@ func (element *DxfParseable) Parse(tags TagSlice) error {
 				return err
 			}
 		} else {
-			fmt.Printf("Discarding tag: %+v\n", tag.ToString())
+			Log.Printf("Discarding tag: %+v\n", tag.ToString())
 		}
 	}
 	return nil

--- a/core/log.go
+++ b/core/log.go
@@ -1,0 +1,8 @@
+package core
+
+import (
+	"log"
+	"os"
+)
+
+var Log *log.Logger = log.New(os.Stderr, "dxf-go", 0)

--- a/document/dxf_document.go
+++ b/document/dxf_document.go
@@ -1,10 +1,10 @@
 package document
 
 import (
-	"fmt"
+	"io"
+
 	"github.com/rpaloschi/dxf-go/core"
 	"github.com/rpaloschi/dxf-go/sections"
-	"io"
 )
 
 // DxfDocument the representation of a full dxf document.
@@ -69,7 +69,7 @@ func DxfDocumentFromStream(stream io.Reader) (*DxfDocument, error) {
 				return nil, err
 			}
 		} else {
-			fmt.Printf("Ignoring unsupported Section type: %+v\n", sectionType)
+			core.Log.Printf("Ignoring unsupported Section type: %+v\n", sectionType)
 		}
 	}
 

--- a/entities/polyline.go
+++ b/entities/polyline.go
@@ -1,7 +1,6 @@
 package entities
 
 import (
-	"fmt"
 	"github.com/rpaloschi/dxf-go/core"
 )
 
@@ -78,7 +77,7 @@ func (p *Polyline) AddNestedEntities(entities EntitySlice) {
 		if vertex, ok := entity.(*Vertex); ok {
 			p.Vertices = append(p.Vertices, vertex)
 		} else {
-			fmt.Printf(
+			core.Log.Printf(
 				"Skipping entity %v. Polylines can only contain Vertex entities.",
 				entity)
 		}

--- a/sections/entities.go
+++ b/sections/entities.go
@@ -1,7 +1,6 @@
 package sections
 
 import (
-	"fmt"
 	"github.com/rpaloschi/dxf-go/core"
 	"github.com/rpaloschi/dxf-go/entities"
 )
@@ -72,7 +71,7 @@ func NewEntityList(tags []core.TagSlice) (entities.EntitySlice, error) {
 				entityList = append(entityList, entity)
 			}
 		} else {
-			fmt.Printf("Unsupported Entity Type: %v", entityType)
+			core.Log.Printf("Unsupported Entity Type: %v", entityType)
 		}
 	}
 

--- a/sections/linetype.go
+++ b/sections/linetype.go
@@ -1,7 +1,6 @@
 package sections
 
 import (
-	"fmt"
 	"github.com/rpaloschi/dxf-go/core"
 )
 
@@ -99,9 +98,9 @@ func NewLineType(tags core.TagSlice) (*LineType, error) {
 		}),
 		75: core.NewIntTypeParser(func(flags int) {
 			if flags74 == 0 {
-				fmt.Print("WARNING! there should be no 75 Code tag if 74 value is 0\n")
+				core.Log.Print("WARNING! there should be no 75 Code tag if 74 value is 0\n")
 			} else if lineElement.IsTextString && flags != 0 {
-				fmt.Print("WARNING! Tag 75 should be 0 if 74 is a TextString\n")
+				core.Log.Print("WARNING! Tag 75 should be 0 if 74 is a TextString\n")
 			} else if lineElement.IsShape {
 				lineElement.ShapeNumber = flags
 			}

--- a/sections/tables.go
+++ b/sections/tables.go
@@ -1,7 +1,6 @@
 package sections
 
 import (
-	"fmt"
 	"github.com/rpaloschi/dxf-go/core"
 )
 
@@ -89,7 +88,7 @@ func NewTablesSection(tags core.TagSlice) (*TablesSection, error) {
 					return nil, err
 				}
 			} else {
-				fmt.Printf("Ignoring unknown table type: %+v\n", tableType)
+				core.Log.Printf("Ignoring unknown table type: %+v\n", tableType)
 			}
 		}
 	}


### PR DESCRIPTION
This is useful when you want to print something useful to stdout. I
added a Logger to the core package, maybe it's not the best place to do
that.

forgot the log.go file the first time, and messed up with git in the process of amending my patch =_=