### PR TITLE
Support Int64 types

### DIFF
--- a/core/data_types.go
+++ b/core/data_types.go
@@ -55,19 +55,19 @@ func (s String) Equals(other DxfElement) bool {
 
 // Integer DataType implementation
 type Integer struct {
-	value int
+	value int64
 }
 
 // NewInteger creates a new Integer object with the provided value as a string
 func NewInteger(value string) (DataType, error) {
 	returnValue := new(Integer)
-	v, err := strconv.Atoi(value)
+	v, err := strconv.ParseInt(value, 10, 64)
 	returnValue.value = v
 	return returnValue, err
 }
 
 // NewIntegerValue creates a new Integer object with provided int.
-func NewIntegerValue(value int) *Integer {
+func NewIntegerValue(value int64) *Integer {
 	returnValue := new(Integer)
 	returnValue.value = value
 	return returnValue
@@ -75,7 +75,7 @@ func NewIntegerValue(value int) *Integer {
 
 // ToString returns a string representation of the value
 func (i Integer) ToString() string {
-	return strconv.Itoa(i.value)
+	return strconv.FormatInt(i.value, 10)
 }
 
 // Value returns the encapsulated value
@@ -140,8 +140,8 @@ func AsString(d DataType) (string, bool) {
 
 // AsInt is the acessor for an Integer DataType.
 // If d is Integer, it will return the (value, true), otherwise (0, false)
-func AsInt(d DataType) (int, bool) {
-	value, ok := d.Value().(int)
+func AsInt(d DataType) (int64, bool) {
+	value, ok := d.Value().(int64)
 	return value, ok
 }
 

--- a/core/data_types_test.go
+++ b/core/data_types_test.go
@@ -41,7 +41,7 @@ func (suite *DataTypesTestSuite) TestAsString() {
 func (suite *DataTypesTestSuite) TestAsInteger() {
 	value, ok := AsInt(suite.intType)
 	suite.True(ok)
-	suite.Equal(2017, value)
+	suite.Equal(int64(2017), value)
 
 	_, ok = AsInt(suite.strType)
 	suite.False(ok)

--- a/core/dxf_parseable.go
+++ b/core/dxf_parseable.go
@@ -13,7 +13,7 @@ type TypeParser interface {
 type SetStringFunc func(string)
 
 // SetIntFunc is a function that sets an integer value.
-type SetIntFunc func(int)
+type SetIntFunc func(int64)
 
 // SetFloatFunc is a function that sets a floating point value.
 type SetFloatFunc func(float64)
@@ -76,9 +76,9 @@ func NewIntTypeParser(setter SetIntFunc) *IntTypeParser {
 
 // NewIntTypeParserToVar creates a new IntTypeParser that sets the parsed
 // value to the value of the passed int pointer.
-func NewIntTypeParserToVar(variable *int) *IntTypeParser {
+func NewIntTypeParserToVar(variable *int64) *IntTypeParser {
 	parser := new(IntTypeParser)
-	parser.setter = func(value int) {
+	parser.setter = func(value int64) {
 		*variable = value
 	}
 	return parser

--- a/core/dxf_parseable_test.go
+++ b/core/dxf_parseable_test.go
@@ -1,9 +1,10 @@
 package core
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 func TestStringTypeParser(t *testing.T) {
@@ -23,7 +24,7 @@ func TestStringTypeParser(t *testing.T) {
 func TestStringTypeParserInvalidType(t *testing.T) {
 	parser := NewStringTypeParser(func(value string) {})
 
-	expected := 1000
+	expected := int64(1000)
 	err := parser.Parse(NewIntegerValue(expected))
 
 	assert.Equal(t,
@@ -41,13 +42,13 @@ func TestStringTypeParserToVar(t *testing.T) {
 }
 
 func TestIntTypeParser(t *testing.T) {
-	var returned int
+	var returned int64
 
-	parser := NewIntTypeParser(func(value int) {
+	parser := NewIntTypeParser(func(value int64) {
 		returned = value
 	})
 
-	expected := 1000
+	expected := int64(1000)
 	err := parser.Parse(NewIntegerValue(expected))
 
 	assert.Nil(t, err)
@@ -55,7 +56,7 @@ func TestIntTypeParser(t *testing.T) {
 }
 
 func TestIntTypeParserInvalidType(t *testing.T) {
-	parser := NewIntTypeParser(func(value int) {})
+	parser := NewIntTypeParser(func(value int64) {})
 
 	expected := 10.50
 	err := parser.Parse(NewFloatValue(expected))
@@ -66,8 +67,8 @@ func TestIntTypeParserInvalidType(t *testing.T) {
 }
 
 func TestIntTypeParserToVar(t *testing.T) {
-	var returned int
-	expected := 1234
+	var returned int64
+	expected := int64(1234)
 	err := NewIntTypeParserToVar(&returned).Parse(NewIntegerValue(expected))
 
 	assert.Nil(t, err)
@@ -112,7 +113,7 @@ type DxfElementTestSuite struct {
 	suite.Suite
 	element     *DxfParseable
 	stringValue string
-	intValue    int
+	intValue    int64
 	floatValue  float64
 }
 
@@ -136,7 +137,7 @@ func (suite *DxfElementTestSuite) TestValidTags() {
 	suite.Nil(err)
 	suite.Equal("Fifteen", suite.stringValue)
 	suite.Equal(1.5, suite.floatValue)
-	suite.Equal(15, suite.intValue)
+	suite.Equal(int64(15), suite.intValue)
 }
 
 func (suite *DxfElementTestSuite) TestUpdate() {
@@ -176,7 +177,7 @@ func (suite *DxfElementTestSuite) TestUnregisteredTagIsIgnored() {
 
 	err := suite.element.Parse(tags)
 	suite.Nil(err)
-	suite.Equal(15, suite.intValue)
+	suite.Equal(int64(15), suite.intValue)
 }
 
 func TestDxfElementTestSuite(t *testing.T) {

--- a/core/tags.go
+++ b/core/tags.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -78,7 +79,12 @@ func Tagger(stream io.Reader) NextTagFunction {
 			if err != nil {
 				return &NoneTag, err
 			}
-			valueType, _ := groupCodeTypes[intCode](strings.Trim(value, charsToTrim))
+			f, ok := groupCodeTypes[intCode]
+			if !ok {
+				Log.Printf("Skipping unknown groupCodeType: %v (value: %v)", intCode, strings.Trim(value, charsToTrim))
+				return &NoneTag, errors.New("unknown groupCodeType")
+			}
+			valueType, _ := f(strings.Trim(value, charsToTrim))
 			tag := new(Tag)
 			tag.Code = intCode
 			tag.Value = valueType
@@ -300,7 +306,7 @@ func init() {
 		groupCodeTypes[code] = NewFloat
 	}
 
-	for code := 170; code < 180; code++ {
+	for code := 160; code < 180; code++ {
 		groupCodeTypes[code] = NewInteger
 	}
 

--- a/entities/entity.go
+++ b/entities/entity.go
@@ -81,13 +81,13 @@ type BaseEntity struct {
 	LayerName     string
 	LineTypeName  string
 	On            bool
-	Color         int
-	LineWeight    int
+	Color         int64
+	LineWeight    int64
 	LineTypeScale float64
 	Visible       bool
 	TrueColor     core.TrueColor
 	ColorName     string
-	Transparency  int
+	Transparency  int64
 	ShadowMode    ShadowMode
 }
 
@@ -121,27 +121,27 @@ func (entity *BaseEntity) InitBaseEntityParser() {
 		6:  core.NewStringTypeParserToVar(&entity.LineTypeName),
 		8:  core.NewStringTypeParserToVar(&entity.LayerName),
 		48: core.NewFloatTypeParserToVar(&entity.LineTypeScale),
-		60: core.NewIntTypeParser(func(value int) {
+		60: core.NewIntTypeParser(func(value int64) {
 			entity.Visible = value == 0
 		}),
-		62: core.NewIntTypeParser(func(value int) {
+		62: core.NewIntTypeParser(func(value int64) {
 			if value < 0 {
 				entity.On = false
 				value = -value
 			}
 			entity.Color = value
 		}),
-		67: core.NewIntTypeParser(func(value int) {
+		67: core.NewIntTypeParser(func(value int64) {
 			entity.Space = Space(value)
 		}),
-		284: core.NewIntTypeParser(func(value int) {
+		284: core.NewIntTypeParser(func(value int64) {
 			entity.ShadowMode = ShadowMode(value)
 		}),
 		330: core.NewStringTypeParserToVar(&entity.Owner),
 		370: core.NewIntTypeParserToVar(&entity.LineWeight),
 		410: core.NewStringTypeParserToVar(&entity.LayoutTabName),
 
-		420: core.NewIntTypeParser(func(value int) {
+		420: core.NewIntTypeParser(func(value int64) {
 			entity.TrueColor = core.TrueColor(value)
 		}),
 		430: core.NewStringTypeParserToVar(&entity.ColorName),

--- a/entities/insert.go
+++ b/entities/insert.go
@@ -13,8 +13,8 @@ type Insert struct {
 	ScaleFactorY       float64
 	ScaleFactorZ       float64
 	RotationAngle      float64
-	ColumnCount        int
-	RowCount           int
+	ColumnCount        int64
+	RowCount           int64
 	ColumnSpacing      float64
 	RowSpacing         float64
 	AttributesFollow   bool
@@ -82,7 +82,7 @@ func NewInsert(tags core.TagSlice) (*Insert, error) {
 		44: core.NewFloatTypeParserToVar(&insert.ColumnSpacing),
 		45: core.NewFloatTypeParserToVar(&insert.RowSpacing),
 		50: core.NewFloatTypeParserToVar(&insert.RotationAngle),
-		66: core.NewIntTypeParser(func(value int) {
+		66: core.NewIntTypeParser(func(value int64) {
 			insert.AttributesFollow = value == 1
 		}),
 		70:  core.NewIntTypeParserToVar(&insert.ColumnCount),

--- a/entities/lwpolyline.go
+++ b/entities/lwpolyline.go
@@ -43,11 +43,11 @@ func NewLWPolyline(tags core.TagSlice) (*LWPolyline, error) {
 
 	pointIndex := -1
 	polyline.Update(map[int]core.TypeParser{
-		70: core.NewIntTypeParser(func(flags int) {
+		70: core.NewIntTypeParser(func(flags int64) {
 			polyline.Closed = flags&closedBit != 0
 			polyline.Plinegen = flags&plinegenBit != 0
 		}),
-		90: core.NewIntTypeParser(func(value int) {
+		90: core.NewIntTypeParser(func(value int64) {
 			polyline.Points = make(LWPolyLinePointSlice, value)
 		}),
 		38: core.NewFloatTypeParserToVar(&polyline.Elevation),
@@ -60,7 +60,7 @@ func NewLWPolyline(tags core.TagSlice) (*LWPolyline, error) {
 		20: core.NewFloatTypeParser(func(y float64) {
 			polyline.Points[pointIndex].Point.Y = y
 		}),
-		91: core.NewIntTypeParser(func(value int) {
+		91: core.NewIntTypeParser(func(value int64) {
 			polyline.Points[pointIndex].Id = value
 		}),
 		40: core.NewFloatTypeParser(func(value float64) {
@@ -104,7 +104,7 @@ func (p LWPolyLinePointSlice) Equals(other LWPolyLinePointSlice) bool {
 // LWPolyLinePoint point and attributes in an LWPolyline.
 type LWPolyLinePoint struct {
 	Point         core.Point
-	Id            int
+	Id            int64
 	StartingWidth float64
 	EndWidth      float64
 	Bulge         float64

--- a/entities/polyline.go
+++ b/entities/polyline.go
@@ -19,10 +19,10 @@ type Polyline struct {
 	LineTypeParentAround   bool
 	DefaultStartWidth      float64
 	DefaultEndWidth        float64
-	VertexCountM           int
-	VertexCountN           int
-	SmoothDensityM         int
-	SmoothDensityN         int
+	VertexCountM           int64
+	VertexCountN           int64
+	SmoothDensityM         int64
+	SmoothDensityN         int64
 	SmoothSurface          SmoothSurfaceType
 	ExtrusionDirection     core.Point
 	Vertices               VertexSlice
@@ -107,7 +107,7 @@ func NewPolyline(tags core.TagSlice) (*Polyline, error) {
 		39: core.NewFloatTypeParserToVar(&polyline.Thickness),
 		40: core.NewFloatTypeParserToVar(&polyline.DefaultStartWidth),
 		41: core.NewFloatTypeParserToVar(&polyline.DefaultEndWidth),
-		70: core.NewIntTypeParser(func(flags int) {
+		70: core.NewIntTypeParser(func(flags int64) {
 			polyline.Closed = flags&closedPolylineBit != 0
 			polyline.CurveFitVerticesAdded = flags&curveFitVerticesAddedBit != 0
 			polyline.SplineFitVerticesAdded = flags&splineFitVerticesAddedBit != 0
@@ -121,7 +121,7 @@ func NewPolyline(tags core.TagSlice) (*Polyline, error) {
 		72: core.NewIntTypeParserToVar(&polyline.VertexCountN),
 		73: core.NewIntTypeParserToVar(&polyline.SmoothDensityM),
 		74: core.NewIntTypeParserToVar(&polyline.SmoothDensityN),
-		75: core.NewIntTypeParser(func(value int) {
+		75: core.NewIntTypeParser(func(value int64) {
 			polyline.SmoothSurface = SmoothSurfaceType(value)
 		}),
 		210: core.NewFloatTypeParserToVar(&polyline.ExtrusionDirection.X),

--- a/entities/spline.go
+++ b/entities/spline.go
@@ -11,7 +11,7 @@ type Spline struct {
 	Rational              bool
 	Planar                bool
 	Linear                bool
-	Degree                int
+	Degree                int64
 	KnotTolerance         float64
 	ControlPointTolerance float64
 	FitTolerance          float64
@@ -104,7 +104,7 @@ func NewSpline(tags core.TagSlice) (*Spline, error) {
 		42: core.NewFloatTypeParserToVar(&spline.KnotTolerance),
 		43: core.NewFloatTypeParserToVar(&spline.ControlPointTolerance),
 		44: core.NewFloatTypeParserToVar(&spline.FitTolerance),
-		70: core.NewIntTypeParser(func(flags int) {
+		70: core.NewIntTypeParser(func(flags int64) {
 			spline.Closed = flags&closedSplineBit != 0
 			spline.Periodic = flags&periodicSplineBit != 0
 			spline.Rational = flags&rationalSplineBit != 0

--- a/entities/text.go
+++ b/entities/text.go
@@ -89,14 +89,14 @@ func NewText(tags core.TagSlice) (*Text, error) {
 		41: core.NewFloatTypeParserToVar(&text.RelativeXScale),
 		50: core.NewFloatTypeParserToVar(&text.Rotation),
 		51: core.NewFloatTypeParserToVar(&text.ObliqueAngle),
-		71: core.NewIntTypeParser(func(flags int) {
+		71: core.NewIntTypeParser(func(flags int64) {
 			text.MirroredX = flags&backwardTextBit != 0
 			text.MirroredY = flags&upsideDownTextBit != 0
 		}),
-		72: core.NewIntTypeParser(func(value int) {
+		72: core.NewIntTypeParser(func(value int64) {
 			text.HorizontalJustification = HorizontalTextJustification(value)
 		}),
-		73: core.NewIntTypeParser(func(value int) {
+		73: core.NewIntTypeParser(func(value int64) {
 			text.VerticalJustification = VerticalTextJustification(value)
 		}),
 		11:  core.NewFloatTypeParserToVar(&text.SecondAlignmentPoint.X),

--- a/entities/vertex.go
+++ b/entities/vertex.go
@@ -17,7 +17,7 @@ type Vertex struct {
 	Is3dPolylineMesh         bool
 	IsPolyfaceMeshVertex     bool
 	CurveFitTangentDirection float64
-	Id                       int
+	Id                       int64
 }
 
 // Equals tests equality against another Vertex.
@@ -63,7 +63,7 @@ func NewVertex(tags core.TagSlice) (*Vertex, error) {
 		41: core.NewFloatTypeParserToVar(&vertex.EndWidth),
 		42: core.NewFloatTypeParserToVar(&vertex.Bulge),
 		50: core.NewFloatTypeParserToVar(&vertex.CurveFitTangentDirection),
-		70: core.NewIntTypeParser(func(flags int) {
+		70: core.NewIntTypeParser(func(flags int64) {
 			vertex.CreatedByCurveFitting = flags&extraVertexCurveFittingBit != 0
 			vertex.CurveFitTangentDefined = flags&curveFitTangentDefinedBit != 0
 			vertex.SplineVertex = flags&splineVertexCreatedBit != 0

--- a/sections/layer.go
+++ b/sections/layer.go
@@ -11,7 +11,7 @@ const frozenBit = 0x1
 type Layer struct {
 	core.DxfParseable
 	Name     string
-	Color    int
+	Color    int64
 	LineType string
 	Locked   bool
 	Frozen   bool
@@ -41,11 +41,11 @@ func NewLayer(tags core.TagSlice) (*Layer, error) {
 
 	layer.Init(map[int]core.TypeParser{
 		2: core.NewStringTypeParserToVar(&layer.Name),
-		70: core.NewIntTypeParser(func(flags int) {
+		70: core.NewIntTypeParser(func(flags int64) {
 			layer.Frozen = flags&frozenBit != 0
 			layer.Locked = flags&lockBit != 0
 		}),
-		62: core.NewIntTypeParser(func(color int) {
+		62: core.NewIntTypeParser(func(color int64) {
 			if color < 0 {
 				layer.On = false
 				layer.Color = -color

--- a/sections/layer_test.go
+++ b/sections/layer_test.go
@@ -1,10 +1,11 @@
 package sections
 
 import (
-	"github.com/rpaloschi/dxf-go/core"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/rpaloschi/dxf-go/core"
+	"github.com/stretchr/testify/assert"
 )
 
 const dxfLayer = `  2
@@ -31,7 +32,7 @@ func TestLayer(t *testing.T) {
 	assert.True(t, layer.Locked)
 	assert.True(t, layer.Frozen)
 	assert.True(t, layer.On)
-	assert.Equal(t, 10, layer.Color)
+	assert.Equal(t, int64(10), layer.Color)
 	assert.Equal(t, "CONTINUOUS", layer.LineType)
 }
 
@@ -43,7 +44,7 @@ func TestLayerDefaultValues(t *testing.T) {
 	assert.False(t, layer.Locked)
 	assert.False(t, layer.Frozen)
 	assert.True(t, layer.On)
-	assert.Equal(t, 7, layer.Color)
+	assert.Equal(t, int64(7), layer.Color)
 	assert.Equal(t, "", layer.LineType)
 }
 
@@ -63,7 +64,7 @@ func TestOffLayer(t *testing.T) {
 	layer, _ := layerFromDxfFragment("  62\n-4")
 
 	assert.False(t, layer.On)
-	assert.Equal(t, 4, layer.Color)
+	assert.Equal(t, int64(4), layer.Color)
 }
 
 const sampleLayerTable = `  0

--- a/sections/linetype.go
+++ b/sections/linetype.go
@@ -14,7 +14,7 @@ type LineElement struct {
 	AbsoluteRotation bool
 	IsTextString     bool
 	IsShape          bool
-	ShapeNumber      int
+	ShapeNumber      int64
 	Scale            float64
 	RotationAngle    float64
 	XOffset          float64
@@ -73,7 +73,7 @@ func NewLineType(tags core.TagSlice) (*LineType, error) {
 	ltype := new(LineType)
 	ltype.Pattern = make([]*LineElement, 0)
 
-	flags74 := 0
+	var flags74 int64
 	var lineElement *LineElement
 
 	ltype.Init(map[int]core.TypeParser{
@@ -88,7 +88,7 @@ func NewLineType(tags core.TagSlice) (*LineType, error) {
 			lineElement.Scale = 1.0
 			lineElement.Length = length
 		}),
-		74: core.NewIntTypeParser(func(flags int) {
+		74: core.NewIntTypeParser(func(flags int64) {
 			flags74 = flags
 			if flags74 > 0 {
 				lineElement.AbsoluteRotation = flags74&absRotationBit > 0
@@ -96,7 +96,7 @@ func NewLineType(tags core.TagSlice) (*LineType, error) {
 				lineElement.IsShape = flags74&elementShapeBit > 0
 			}
 		}),
-		75: core.NewIntTypeParser(func(flags int) {
+		75: core.NewIntTypeParser(func(flags int64) {
 			if flags74 == 0 {
 				core.Log.Print("WARNING! there should be no 75 Code tag if 74 value is 0\n")
 			} else if lineElement.IsTextString && flags != 0 {

--- a/sections/linetype_test.go
+++ b/sections/linetype_test.go
@@ -1,11 +1,12 @@
 package sections
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/rpaloschi/dxf-go/core"
 	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 func lineTypeFromDxfFragment(fragment string) (*LineType, error) {
@@ -298,7 +299,7 @@ func TestParseLineTypeShapeNr(t *testing.T) {
 	lineType, err := lineTypeFromDxfFragment(dxfLineTypeShapeNrNoShapeOrText)
 
 	assert.Nil(t, err)
-	assert.Equal(t, 0, lineType.Pattern[0].ShapeNumber)
+	assert.Equal(t, int64(0), lineType.Pattern[0].ShapeNumber)
 }
 
 const dxfLineTypeShapeNrNot0AndText = `  0
@@ -329,7 +330,7 @@ func TestParseLineTypeShapeNrWhenIsText(t *testing.T) {
 	lineType, err := lineTypeFromDxfFragment(dxfLineTypeShapeNrNot0AndText)
 
 	assert.Nil(t, err)
-	assert.Equal(t, 0, lineType.Pattern[0].ShapeNumber)
+	assert.Equal(t, int64(0), lineType.Pattern[0].ShapeNumber)
 }
 
 func TestCompareLineTypeWrongType(t *testing.T) {

--- a/sections/style.go
+++ b/sections/style.go
@@ -56,11 +56,11 @@ func NewStyle(tags core.TagSlice) (*Style, error) {
 		40: core.NewFloatTypeParserToVar(&style.Height),
 		41: core.NewFloatTypeParserToVar(&style.Width),
 		50: core.NewFloatTypeParserToVar(&style.Oblique),
-		70: core.NewIntTypeParser(func(flags int) {
+		70: core.NewIntTypeParser(func(flags int64) {
 			style.IsShape = flags&shapeBit != 0
 			style.IsVerticalText = flags&verticalTextBit != 0
 		}),
-		71: core.NewIntTypeParser(func(flags int) {
+		71: core.NewIntTypeParser(func(flags int64) {
 			style.IsBackwards = flags&backwardsBit != 0
 			style.IsUpsideDown = flags&upsideDownBit != 0
 		}),


### PR DESCRIPTION
Upgrade all integer types to be 64 bits. Also start logging tags that aren't supported and add extra tags that are 64 bit ints.

I'm working on taking DXF from OnShape and converting to SVG for a laser cutter and hit int64 types.  Hopefully moving to Int64 everywhere is reasonable.